### PR TITLE
add ability to prevent whitelist check on certain vehicles

### DIFF
--- a/functions/whitelist/fn_onVehicleEnter.sqf
+++ b/functions/whitelist/fn_onVehicleEnter.sqf
@@ -8,6 +8,8 @@ if(GVAR(enableSlotTraits)) then {
 	[player, _vehicle] call FUNC(checkslotTrait);
 };
 
+if(! isNil {QGVAR(disabledVehicles)} && { _vehicle in GVAR(disabledVehicles)}) exitWith {};
+
 switch true do {
 	case (_vehicle call EFUNC(util,isHelicopter)): {
 		private _isAllowed = false;


### PR DESCRIPTION
Adds the ability to prevent vehicles inside a list to be checked by the whitelist.
This array can be created and used by the following variable: TF47_whitelist_disabledVehicles

Closes #8