### PR TITLE
Breaking changes! Split unit traits to crew and pilot for flying vehicles

### DIFF
--- a/functions/script_common.hpp
+++ b/functions/script_common.hpp
@@ -36,11 +36,13 @@
 
 #include "..\script_macros_common.hpp"
 
-#define TF47_IS_TANKER "TF47_whitelist_crew_tank"
-#define TF47_IS_PILOT_HELICOPTER "TF47_whitelist_crew_helicopter"
-#define TF47_IS_PILOT_PLANE "TF47_whitelist_crew_plane"
-#define TF47_IS_UAV "TF47_whitelist_crew_uav"
+#define TF47_IS_TANKER "TF47_whitelist_tank_crew"
+#define TF47_IS_HELICOPTER_PILOT "TF47_whitelist_helicopter_pilot"
+#define TF47_IS_PLANE_PILOT "TF47_whitelist_plane_pilot"
+#define TF47_IS_UAV "TF47_whitelist_uav_pilot"
 #define TF47_IS_CCT "TF47_whitelist_slot_cct"
+#define TF47_IS_HELICOPTER_CREW "TF47_whitelist_helicopter_crew"
+#define TF47_IS_PLANE_CREW "TF47_whitelist_plane_crew"
 
 #define IS_SERVER isServer
 #define IS_HEADLESS !hasInterface && !isServer

--- a/functions/whitelist/fn_addSlotTraits.sqf
+++ b/functions/whitelist/fn_addSlotTraits.sqf
@@ -13,19 +13,19 @@ if(_id != -1) exitWith {
 
 _traits = _traits apply {
 	switch _x do {
-		case WHITELIST_TANK: {
+		case TF47_IS_TANKER: {
 			TF47_IS_TANKER
 		};
-		case WHITELIST_HELO: {
+		case TF47_IS_HELICOPTER_PILOT: {
 			TF47_IS_PILOT_HELICOPTER
 		};
-		case WHITELIST_PLANE: {
+		case TF47_IS_PILOT_PLANE: {
 			TF47_IS_PILOT_PLANE
 		};
-		case WHITELIST_CCT: {
+		case TF47_IS_CCT: {
 			TF47_IS_CCT
 		};
-		case WHITELIST_UAV: {
+		case TF47_IS_UAV: {
 			TF47_IS_UAV
 		};
 		case TF47_IS_PLANE_CREW: {

--- a/functions/whitelist/fn_addSlotTraits.sqf
+++ b/functions/whitelist/fn_addSlotTraits.sqf
@@ -25,6 +25,15 @@ _traits = _traits apply {
 		case WHITELIST_CCT: {
 			TF47_IS_CCT
 		};
+		case WHITELIST_UAV: {
+			TF47_IS_UAV
+		};
+		case TF47_IS_PLANE_CREW: {
+			TF47_IS_PLANE_CREW
+		};
+		case TF47_IS_HELICOPTER_CREW: {
+			TF47_IS_HELICOPTER_CREW
+		};
 		default {
 			nil
 		};
@@ -34,6 +43,5 @@ _traits = _traits apply {
 _traits = _traits select {! isNil "_x"};
 GVAR(slotTraits) pushBack [_slotName, _traits];
 publicVariable QGVAR(slotTraits);
-
 
 true

--- a/functions/whitelist/fn_checkSlotTrait.sqf
+++ b/functions/whitelist/fn_checkSlotTrait.sqf
@@ -20,10 +20,10 @@ switch true do {
     };
   };
   case (_vehicle call EFUNC(util,isHelicopter)): {
-    if (_unit isEqualTo driver _vehicle && {! _unit getUnitTrait TF47_IS_HELICOPTER_PILOT}) exitWith {
+    if (_unit isEqualTo driver _vehicle && {! _unit getUnitTrait TF47_IS_HELICOPTER_PILOT }) exitWith {
       [_unit, "You must be on the pilot slot to fly this vehicle"] call FUNC(kickPlayerVehicle);
     };
-    if(! (_unit getUnitTrait TF47_IS_HELICOPTER_CREW || _unit getUnitTrait TF47_IS_HELICOPTER_PILOT)) exitWith {
+    if(! (_unit getUnitTrait TF47_IS_HELICOPTER_CREW || { _unit getUnitTrait TF47_IS_HELICOPTER_PILOT })) exitWith {
       [_unit, "You do not have the correct slot to use this vehicle"] call FUNC(kickPlayerVehicle);
     };
   };
@@ -31,7 +31,7 @@ switch true do {
     if (_unit isEqualTo driver _vehicle && {! _unit getUnitTrait TF47_IS_PLANE_PILOT}) exitWith {
       [_unit, "You must be on the pilot slot to fly this vehicle"] call FUNC(kickPlayerVehicle);
     };
-    if(! (_unit getUnitTrait TF47_IS_PLANE_CREW || _unit getUnitTrait TF47_IS_PLANE_PILOT) exitWith {
+    if(! (_unit getUnitTrait TF47_IS_PLANE_CREW || { _unit getUnitTrait TF47_IS_PLANE_PILOT })) exitWith {
       [_unit, "You do not have the correct slot to use this vehicle"] call FUNC(kickPlayerVehicle);
     };
   };

--- a/functions/whitelist/fn_checkSlotTrait.sqf
+++ b/functions/whitelist/fn_checkSlotTrait.sqf
@@ -20,12 +20,18 @@ switch true do {
     };
   };
   case (_vehicle call EFUNC(util,isHelicopter)): {
-    if(! (_unit getUnitTrait TF47_IS_PILOT_HELICOPTER)) exitWith {
+    if (_unit isEqualTo driver _vehicle && {! _unit getUnitTrait TF47_IS_HELICOPTER_PILOT}) exitWith {
+      [_unit, "You must be on the pilot slot to fly this vehicle"] call FUNC(kickPlayerVehicle);
+    };
+    if(! (_unit getUnitTrait TF47_IS_HELICOPTER_CREW || _unit getUnitTrait TF47_IS_HELICOPTER_PILOT)) exitWith {
       [_unit, "You do not have the correct slot to use this vehicle"] call FUNC(kickPlayerVehicle);
     };
   };
   case (_vehicle call EFUNC(util,isPlane)): {
-    if(! (_unit getUnitTrait TF47_IS_PILOT_PLANE)) exitWith {
+    if (_unit isEqualTo driver _vehicle && {! _unit getUnitTrait TF47_IS_PLANE_PILOT}) exitWith {
+      [_unit, "You must be on the pilot slot to fly this vehicle"] call FUNC(kickPlayerVehicle);
+    };
+    if(! (_unit getUnitTrait TF47_IS_PLANE_CREW || _unit getUnitTrait TF47_IS_PLANE_PILOT) exitWith {
       [_unit, "You do not have the correct slot to use this vehicle"] call FUNC(kickPlayerVehicle);
     };
   };


### PR DESCRIPTION
When pulled only units with trait of pilot will be able to fly a plane. 
However to make API interfaces clear, some traits had to be renamed.

The current active list:
```
#define TF47_IS_TANKER "TF47_whitelist_tank_crew"
#define TF47_IS_HELICOPTER_PILOT "TF47_whitelist_helicopter_pilot"
#define TF47_IS_PLANE_PILOT "TF47_whitelist_plane_pilot"
#define TF47_IS_UAV "TF47_whitelist_uav_pilot"
#define TF47_IS_CCT "TF47_whitelist_slot_cct"
#define TF47_IS_HELICOPTER_CREW "TF47_whitelist_helicopter_crew"
#define TF47_IS_PLANE_CREW "TF47_whitelist_plane_crew"
```
