### PR TITLE
fixed uav whitelist was not working

### DIFF
--- a/functions/whitelist/fn_initPlayer.sqf
+++ b/functions/whitelist/fn_initPlayer.sqf
@@ -33,5 +33,10 @@ LOG("STARTING WHITELIST PLAYER INIT");
 	systemChat "whitelist updated!";
 }] call CBA_fnc_registerChatCommand;
 
+addMissionEventHandler ["PlayerViewChanged", {
+	params ["", "_newUnit", "", "", "", "_uav"];
+	[_newUnit, _uav] call FUNC(handleUavCheck);
+}];
+
 
 LOG("FINISHED WHITELIST PLAYER INIT");

--- a/functions/whitelist/fn_initServer.sqf
+++ b/functions/whitelist/fn_initServer.sqf
@@ -4,8 +4,3 @@ if(! GVAR(enableWhitelist)) then {};
 
 GVAR(slotWhitelist) = [];
 GVAR(slotTraits) = [];
-
-addMissionEventHandler ["PlayerViewChanged", {
-	params ["", "_newUnit", "", "", "", "_uav"];
-	[_newUnit, _uav] remoteExec [QFUNC(handleUavCheck), _newUnit];
-}];


### PR DESCRIPTION
* due to locality issue of playerviewchanged mission eventhandler, the event would not fire and therefor anyone could use the uav without whitelist